### PR TITLE
Decrease max_rows limit in config.toml

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -13,7 +13,7 @@ schemas = ["public", "storage", "graphql_public"]
 extra_search_path = ["public", "extensions"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
 # for accidental or malicious requests.
-max_rows = 1000
+max_rows = 990
 
 [db]
 # Port to use for the local database URL.


### PR DESCRIPTION
Reduced the maximum number of rows returned from 1000 to 990.